### PR TITLE
Fixed clean hooks mechanism

### DIFF
--- a/single_app_hooks/single_app_hooks.test
+++ b/single_app_hooks/single_app_hooks.test
@@ -3,7 +3,6 @@ TERM=dumb rebar3 clean
 ===> Verifying dependencies...
 ===> Cleaning out single_app_hooks...
 CLEAN!
-CLEAN!
 >>>= 0
 
 TERM=dumb rebar3 compile


### PR DESCRIPTION
As mentioned in https://github.com/erlang/rebar3/pull/2863, fixing the `clean` hooks appears to have fixed their count by properly assigning them in the top-level app in a non-umbrella project. See how [the multi app file](https://github.com/tsloughter/rebar3_tests/blob/cba67afa851747bcdb5294c9d88c697f0d814b3c/multi_app_hooks/multi_app_hooks.test#L5) has a single `CLEAN!` hook but [the single app one had two for clean](https://github.com/tsloughter/rebar3_tests/blob/cba67afa851747bcdb5294c9d88c697f0d814b3c/single_app_hooks/single_app_hooks.test#L5-L6) while [having a single one for compile](https://github.com/tsloughter/rebar3_tests/blob/cba67afa851747bcdb5294c9d88c697f0d814b3c/single_app_hooks/single_app_hooks.test#L14).

This is because the discovery step we weren't doing right before the PR meant that the hook was assigned both to the project and the individual app. By fixing the detection and overrides, the hook is properly assigned to the app in a single-app project, and to the project root when in an umbrella.

This PR prepares tests to pass once the rebar3 one is merged.