### PR TITLE
Update single_app_hooks.test for leaner clean

### DIFF
--- a/single_app_hooks/single_app_hooks.test
+++ b/single_app_hooks/single_app_hooks.test
@@ -1,6 +1,5 @@
 TERM=dumb rebar3 clean
 >>>
-===> Verifying dependencies...
 ===> Cleaning out single_app_hooks...
 CLEAN!
 >>>= 0


### PR DESCRIPTION
https://github.com/erlang/rebar3/pull/2863 makes it so we stop scanning dependencies when cleaning only top-level apps.